### PR TITLE
Use dateutil.parser to parse timestamps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 on:
   push:
-    branches: master
   pull_request:
 jobs:
   test:

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,5 +4,5 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party=deprecated,httpretty,jwt,nacl,pytest,requests,setuptools,urllib3
+known_third_party=dateutil,deprecated,httpretty,jwt,nacl,pytest,requests,setuptools,urllib3
 known_first_party=github

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -31,8 +31,9 @@
 ################################################################################
 
 import datetime
-from dateutil import parser
 from operator import itemgetter
+
+from dateutil import parser
 
 from . import Consts, GithubException
 

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -31,6 +31,7 @@
 ################################################################################
 
 import datetime
+from dateutil import parser
 from operator import itemgetter
 
 from . import Consts, GithubException
@@ -173,28 +174,7 @@ class GithubObject:
 
     @staticmethod
     def _makeDatetimeAttribute(value):
-        def parseDatetime(s):
-            if (
-                len(s) == 24
-            ):  # pragma no branch (This branch was used only when creating a download)
-                # The Downloads API has been removed. I'm keeping this branch because I have no mean
-                # to check if it's really useless now.
-                return datetime.datetime.strptime(s, "%Y-%m-%dT%H:%M:%S.000Z").replace(
-                    tzinfo=datetime.timezone.utc
-                )  # pragma no cover (This branch was used only when creating a download)
-            elif len(s) >= 25:
-                return datetime.datetime.strptime(s[:19], "%Y-%m-%dT%H:%M:%S").replace(
-                    tzinfo=datetime.timezone(
-                        (-1 if s[19] == "-" else 1)
-                        * datetime.timedelta(hours=int(s[20:22]), minutes=int(s[23:25]))
-                    )
-                )
-            else:
-                return datetime.datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(
-                    tzinfo=datetime.timezone.utc
-                )
-
-        return GithubObject.__makeTransformedAttribute(value, str, parseDatetime)
+        return GithubObject.__makeTransformedAttribute(value, str, parser.parse)
 
     def _makeClassAttribute(self, klass, value):
         return GithubObject.__makeTransformedAttribute(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pynacl>=1.4.0
+python-dateutil
 requests>=2.14.0
 pyjwt>=2.4.0
 sphinx<3

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ if __name__ == "__main__":
             "pyjwt>=2.4.0",
             "pynacl>=1.4.0",
             "requests>=2.14.0",
+            "python-dateutil"
         ],
         extras_require={"integrations": ["cryptography"]},
         tests_require=["cryptography", "httpretty>=1.0.3"],

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
             "pyjwt>=2.4.0",
             "pynacl>=1.4.0",
             "requests>=2.14.0",
-            "python-dateutil"
+            "python-dateutil",
         ],
         extras_require={"integrations": ["cryptography"]},
         tests_require=["cryptography", "httpretty>=1.0.3"],

--- a/tests/BadAttributes.py
+++ b/tests/BadAttributes.py
@@ -29,6 +29,7 @@ import datetime
 from dateutil.parser import ParserError
 
 import github
+
 from . import Framework
 
 

--- a/tests/BadAttributes.py
+++ b/tests/BadAttributes.py
@@ -26,8 +26,9 @@
 
 import datetime
 
-import github
+from dateutil.parser import ParserError
 
+import github
 from . import Framework
 
 
@@ -55,11 +56,11 @@ class BadAttributes(Framework.TestCase):
         self.assertEqual(raisedexp.exception.actual_value, "foobar")
         self.assertEqual(raisedexp.exception.expected_type, str)
         self.assertEqual(
-            raisedexp.exception.transformation_exception.__class__, ValueError
+            raisedexp.exception.transformation_exception.__class__, ParserError
         )
         self.assertEqual(
             raisedexp.exception.transformation_exception.args,
-            ("time data 'foobar' does not match format '%Y-%m-%dT%H:%M:%SZ'",),
+            ("Unknown string format: %s", "foobar"),
         )
 
     def testBadTransformedAttribute(self):

--- a/tests/GithubObject.py
+++ b/tests/GithubObject.py
@@ -34,28 +34,57 @@ class GithubObject(unittest.TestCase):
     def testMakeDatetimeAttribute(self):
         for value, expected in [
             (None, None),
-
-            ("2021-01-23T12:34:56Z", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
-            ("2021-01-23T12:34:56.000Z", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
-            ("2021-01-23T12:34:56.000Z", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
-
-            ("2021-01-23T12:34:56+00:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
-            ("2021-01-23T12:34:56+01:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone(timedelta(hours=1)))),
-            ("2021-01-23T12:34:56-06:30", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone(timedelta(hours=-6, minutes=-30)))),
-
-            ("2021-01-23T12:34:56.000+00:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
-            ("2021-01-23T12:34:56.000+01:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone(timedelta(hours=1)))),
-            ("2021-01-23T12:34:56.000-06:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=tzoffset(None, -21600)))
+            (
+                "2021-01-23T12:34:56Z",
+                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc),
+            ),
+            (
+                "2021-01-23T12:34:56.000Z",
+                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc),
+            ),
+            (
+                "2021-01-23T12:34:56.000Z",
+                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc),
+            ),
+            (
+                "2021-01-23T12:34:56+00:00",
+                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc),
+            ),
+            (
+                "2021-01-23T12:34:56+01:00",
+                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone(timedelta(hours=1))),
+            ),
+            (
+                "2021-01-23T12:34:56-06:30",
+                datetime(
+                    2021,
+                    1,
+                    23,
+                    12,
+                    34,
+                    56,
+                    tzinfo=timezone(timedelta(hours=-6, minutes=-30)),
+                ),
+            ),
+            (
+                "2021-01-23T12:34:56.000+00:00",
+                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc),
+            ),
+            (
+                "2021-01-23T12:34:56.000+01:00",
+                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone(timedelta(hours=1))),
+            ),
+            (
+                "2021-01-23T12:34:56.000-06:00",
+                datetime(2021, 1, 23, 12, 34, 56, tzinfo=tzoffset(None, -21600)),
+            ),
         ]:
             actual = gho.GithubObject._makeDatetimeAttribute(value)
             self.assertEqual(gho._ValuedAttribute, type(actual), value)
             self.assertEqual(expected, actual.value, value)
 
     def testMakeDatetimeAttributeBadValues(self):
-        for value in [
-            "not a timestamp",
-            1234
-        ]:
+        for value in ["not a timestamp", 1234]:
             actual = gho.GithubObject._makeDatetimeAttribute(value)
 
             self.assertEqual(gho._BadAttribute, type(actual))
@@ -75,13 +104,12 @@ class GithubObject(unittest.TestCase):
 
         actual = gho.GithubObject._makeTimestampAttribute(1611405296)
         self.assertEqual(gho._ValuedAttribute, type(actual))
-        self.assertEqual(datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc), actual.value)
+        self.assertEqual(
+            datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc), actual.value
+        )
 
     def testMakeTimetsampAttributeBadValues(self):
-        for value in [
-            "1611405296",
-            1234.567
-        ]:
+        for value in ["1611405296", 1234.567]:
             actual = gho.GithubObject._makeTimestampAttribute(value)
 
             self.assertEqual(gho._BadAttribute, type(actual))

--- a/tests/GithubObject.py
+++ b/tests/GithubObject.py
@@ -20,8 +20,10 @@
 #                                                                              #
 ################################################################################
 
-from datetime import datetime, timedelta, timezone
 import unittest
+from datetime import datetime, timedelta, timezone
+
+from dateutil.tz.tz import tzoffset
 
 from . import Framework
 
@@ -42,8 +44,8 @@ class GithubObject(unittest.TestCase):
             ("2021-01-23T12:34:56-06:30", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone(timedelta(hours=-6, minutes=-30)))),
 
             ("2021-01-23T12:34:56.000+00:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
-            ("2021-01-23T12:34:56.000+01:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
-            ("2021-01-23T12:34:56.000-06:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc))
+            ("2021-01-23T12:34:56.000+01:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone(timedelta(hours=1)))),
+            ("2021-01-23T12:34:56.000-06:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=tzoffset(None, -21600)))
         ]:
             actual = gho.GithubObject._makeDatetimeAttribute(value)
             self.assertEqual(gho._ValuedAttribute, type(actual), value)
@@ -51,10 +53,6 @@ class GithubObject(unittest.TestCase):
 
     def testMakeDatetimeAttributeBadValues(self):
         for value in [
-            "2021-01-23T12:34:56",
-            "2021-01-23T12:34:56.123",
-            "2021-01-23T12:34:56.123Z",
-            "2021-01-23 12:34:56Z",
             "not a timestamp",
             1234
         ]:

--- a/tests/Migration.py
+++ b/tests/Migration.py
@@ -50,6 +50,7 @@ import datetime
 from dateutil.tz.tz import tzoffset
 
 import github
+
 from . import Framework
 
 
@@ -73,9 +74,7 @@ class Migration(Framework.TestCase):
         )
         self.assertEqual(
             self.migration.created_at,
-            datetime.datetime(
-                2018, 9, 14, 1, 35, 35, tzinfo=tzoffset(None, 19800)
-            ),
+            datetime.datetime(2018, 9, 14, 1, 35, 35, tzinfo=tzoffset(None, 19800)),
         )
         self.assertEqual(
             self.migration.updated_at,

--- a/tests/Migration.py
+++ b/tests/Migration.py
@@ -47,8 +47,9 @@
 
 import datetime
 
-import github
+from dateutil.tz.tz import tzoffset
 
+import github
 from . import Framework
 
 
@@ -73,12 +74,12 @@ class Migration(Framework.TestCase):
         self.assertEqual(
             self.migration.created_at,
             datetime.datetime(
-                2018, 9, 14, 1, 35, 35, tzinfo=datetime.timezone(datetime.timedelta(0))
+                2018, 9, 14, 1, 35, 35, tzinfo=tzoffset(None, 19800)
             ),
         )
         self.assertEqual(
             self.migration.updated_at,
-            datetime.datetime(2018, 9, 14, 1, 35, 46, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2018, 9, 14, 1, 35, 46, tzinfo=tzoffset(None, 19800)),
         )
         self.assertEqual(
             repr(self.migration),

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps =
     types-requests
     pre-commit
     mypy
+    types-python-dateutil
 commands =
     pre-commit run --all-files --show-diff-on-failure
     ; Run mypy outside pre-commit because pre-commit runs mypy in a venv


### PR DESCRIPTION
This uses the `dateutil.parser` to parse timestamps. This supports many more (standard) formats.

This also shows some flaws in the current implementation:

[These](https://github.com/jwodder/PyGithub/pull/2/files#diff-61255b8f286fe9135b8ed6c2adccbdc6055ce410450aa702f5a5f87ab069fbb2L45-L46) are clearly not UTC:
```
("2021-01-23T12:34:56.000+01:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
("2021-01-23T12:34:56.000-06:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc))
```

ReplayData contain these values ([Migration.setUp.txt](https://github.com/PyGithub/PyGithub/blob/c7e3ae94214eaa702121d6ff08c92d83af47ebd9/tests/ReplayData/Migration.setUp.txt#L10)):
```
"created_at":"2018-09-14T01:35:35.000+05:30"
"updated_at":"2018-09-14T01:35:46.000+05:30"
```

They should not parse to
```
datetime.timezone(datetime.timedelta(0))
datetime.timezone.utc
```
Note, those two timezones are equal w.r.t. `self.assertEqual`.